### PR TITLE
Allow undef handlers and subscribers

### DIFF
--- a/lib/puppet/type/sensu_check.rb
+++ b/lib/puppet/type/sensu_check.rb
@@ -46,7 +46,8 @@ Puppet::Type.newtype(:sensu_check) do
   newproperty(:handlers, :array_matching => :all) do
     desc "List of handlers that responds to this check"
     def insync?(is)
-      is.sort == should.sort
+      return is.sort == should.sort if is.is_a?(Array) && should.is_a?(Array)
+      is == should
     end
   end
 
@@ -78,7 +79,8 @@ Puppet::Type.newtype(:sensu_check) do
   newproperty(:subscribers, :array_matching => :all) do
     desc "Who is subscribed to this check"
     def insync?(is)
-      is.sort == should.sort
+      return is.sort == should.sort if is.is_a?(Array) && should.is_a?(Array)
+      is == should
     end
   end
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "sensu-sensu",
-  "version": "1.5.5",
+  "version": "1.5.5-ens2",
   "author": "sensu",
   "summary": "A module to install the Sensu monitoring framework",
   "license": "MIT",


### PR DESCRIPTION
This commit fixes the error message: `undefined method`sort' for
nil:NilClass`. This error message can be seen when either the handlers
or subscribers parameters are passed in as`undef` in the check.pp
manifest.

The PRs that looks like they introduced this behavior are:
https://github.com/sensu/sensu-puppet/pull/285
https://github.com/sensu/sensu-puppet/pull/303
